### PR TITLE
Fixes the RSS feed link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ compile_sass = true
 build_search_index = false
 
 generate_feed = true
-feed_filename = "rss.xml"
+feed_filename = "atom.xml"
 
 [markdown]
 # Whether to do syntax highlighting

--- a/templates/base.html
+++ b/templates/base.html
@@ -99,7 +99,7 @@
                             <h5><a href="/privacy">Privacy Policy</a></h5>
                         </li>
                         <li>
-                            <h5><a type="application/atom+xml" href="/feed.xml">Atom (RSS)</a></h5>
+                            <h5><a type="application/atom+xml" title = "SS3D Devlog" href="/atom.xml">Atom (RSS)</a></h5>
                         </li>
                     </ul>
                     <div id="page-counter">


### PR DESCRIPTION
For some reason, the RSS file and the link to it in the base.html do not match. I hope this should fix this. At least I can see "/rss.xml" is available on the website right now.